### PR TITLE
[Apply] : MeetingController 전체 미들웨어 적용하되, GET 메서드만 제외

### DIFF
--- a/src/meeting/meeting.module.ts
+++ b/src/meeting/meeting.module.ts
@@ -27,19 +27,12 @@ import { MeetingUsersModule } from 'src/meeting-users/meeting-users.module';
 })
 export class MeetingModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
-    consumer.apply(JwtMiddleware).forRoutes(
-      {
-        path: 'meeting',
-        method: RequestMethod.POST,
-      },
-      {
-        path: 'meeting/:id',
-        method: RequestMethod.PUT,
-      },
-      {
-        path: 'meeting/:id',
-        method: RequestMethod.DELETE,
-      },
-    );
+    consumer
+      .apply(JwtMiddleware)
+      .exclude({
+        path: '/meeting',
+        method: RequestMethod.GET,
+      })
+      .forRoutes(MeetingController);
   }
 }


### PR DESCRIPTION
`forRoutes(MeetingController)` 선언하여 `/meeting` 경로를 접근하기 위해 `Bearer xxx` 토큰을 받되,

`exlucde({ path : '/meeting', method : RequestMethod.GET})` 으로 GET 라우트만 제외.