### PR TITLE
[Fix] : 미팅 개별 조회 - 토큰 인증 제외

### DIFF
--- a/src/meeting/meeting.module.ts
+++ b/src/meeting/meeting.module.ts
@@ -29,10 +29,16 @@ export class MeetingModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer
       .apply(JwtMiddleware)
-      .exclude({
-        path: 'meeting',
-        method: RequestMethod.GET,
-      })
+      .exclude(
+        {
+          path: 'meeting',
+          method: RequestMethod.GET,
+        },
+        {
+          path: ':id',
+          method: RequestMethod.GET,
+        },
+      )
       .forRoutes(MeetingController);
   }
 }


### PR DESCRIPTION
미팅 개별 조회는 토큰을 필요로 할 수도, 필요 없을 수도 있는 선택적 상황이므로,

내부에서 자체적으로 요청한 유저의 정보가 필요할 때, 따로 예외 처리 해 주어야 함.